### PR TITLE
Updated MongoDB Java driver to 2.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :description "clojure-friendly api for MongoDB"
   :dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]
                  [org.clojure/clojure-contrib "1.2.0-SNAPSHOT"]
-                 [org.mongodb/mongo-java-driver "2.0"]]
+                 [org.mongodb/mongo-java-driver "2.3"]]
   :dev-dependencies [[swank-clojure "1.2.1"]])


### PR DESCRIPTION
There was an issue with an API change on the driver in 2.1 where insert of a single object now requires a WriteConcern to be passed in (http://jira.mongodb.org/browse/JAVA-122).

I've updated the insert! function to handle this case.
