### PR TITLE
Updating to 1.2 stable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject congomongo
   "0.1.3-SNAPSHOT"
   :description "clojure-friendly api for MongoDB"
-  :dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]
-                 [org.clojure/clojure-contrib "1.2.0-SNAPSHOT"]
+  :dependencies [[org.clojure/clojure "1.2.0"]
+                 [org.clojure/clojure-contrib "1.2.0"]
                  [org.mongodb/mongo-java-driver "2.3"]]
   :dev-dependencies [[swank-clojure "1.2.1"]])


### PR DESCRIPTION
Clojure 1.2 is now stable so the dependencies can link to it - otherwise it might not find it's clojure (happend to me) ;)
