### PR TITLE
Allow indexes to be created with a user-defined name

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -281,12 +281,15 @@ releases.  Please use 'make-connection' in combination with
    Similarly, [[:a 1] [:b -1] :c] will generate the same index (\"1\" indicates ascending order, the default).
 
     Options include:
+    :name   -> defaults to the system-generated default
     :unique -> defaults to false
     :force  -> defaults to true"
-   {:arglists '(collection fields {:unique false :force true})}
-   [c f :unique false :force true]
+   {:arglists '(collection fields {:name nil :unique false :force true})}
+   [c f :name nil :unique false :force true]
    (-> (get-coll c)
-       (.ensureIndex (coerce-index-fields f) (coerce {:force force :unique unique} [:clojure :mongo]))))
+       (.ensureIndex (coerce-index-fields f) (coerce (merge {:force force :unique unique}
+                                                            (if name {:name name}))
+                                                     [:clojure :mongo]))))
 
 (defn drop-index!
   "Drops an index on the collection for the specified fields"

--- a/test/congomongo_test.clj
+++ b/test/congomongo_test.clj
@@ -219,6 +219,14 @@
       (is (= actual-index expected-index))
       (is (index-keys-in-same-order actual-index expected-index)))))
 
+(deftest index-name
+  (with-test-mongo
+    (let [coll :test-index-name
+          index "customIndexName"]
+      (add-index! coll [:foo :bar :baz] :name index)
+      (is (= (get (get-named-index coll index)
+                  "key"))))))
+
 (defrecord Foo [a b])
 
 (deftest can-insert-records-as-maps


### PR DESCRIPTION
Comes in handy when the system-defined name of one of your indexes is too long to be a legal index name!
