### PR TITLE
congomongo now preserves the order of the key value pairs

### DIFF
--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -27,7 +27,7 @@
               (assoc m (keyword k) (mongo->clojure v true)))
             (fn [m [#^String k v]]
               (assoc m k (mongo->clojure v false))))
-          (sorted-map) kvs))            ;sorted-map because BasicBSONObject extends LinkedHashMap
+          {} (reverse kvs)))
 
 (extend-protocol ConvertibleFromMongo
   Map


### PR DESCRIPTION
Hi,
at the moment congomongo sorts the key value pairs of a BSON document alphabetically through the use of a sorted-map when fetching it from a MongoDB. This is a little bit messy, if you use the results of congomongo's fetch in your REST API for example. Admittedly the order of the key value pairs doesn't play a role for a computer, but more often than not it would annoy the developer, if he gets an alphabetically sorted result map / json document instead of "logically" sorted one. In my use case I store something like this in my MongoDB:
{:id 123, :width 200, :height 100}
and get back:
{:height 100, :id 123, :width 200}
I would be glad, if this change would be merged into the congomongo's master branch.

Best regards

Max
