### PR TITLE
Added QueryOptions from com.mongodb.Bytes

### DIFF
--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -63,6 +63,15 @@
           (close-connection a)
           (is (= nil *mongo-config*)))))))
 
+(deftest query-options
+  (are [x y] (= (calculate-query-option x) y)
+       nil 0
+       [] 0
+       [:tailable] 2
+       [:tailable :slaveok] 6
+       [:tailable :slaveok :notimeout] 22
+       :notimeout 16))
+
 (deftest fetch-sort
   (with-test-mongo
     (let [unsorted [3 10 7 0 2]]


### PR DESCRIPTION
One query I'm running in production tends to last longer than 10 minutes when the server is under load. This causes the cursor to time out and an exception to be raised. What I'd like to be able to do is: 

   (db/fetch feeds-table
             :where (str "{ \"feed_disabled\" : { \"$ne\" : true }}")
             :from :json
             :sort "{ \"last_modified\" : 1}"
             :options :notimeout)

To make things a bit more generic, I made sure options could be omitted and also supported all the options listed in the Mongo driver.
