### PR TITLE
Allow :only to take a map argument as well as vector, like mongodb shell.

### DIFF
--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -110,7 +110,10 @@
 (defn ^DBObject coerce-fields
   "only used for creating argument object for :only"
   [fields]
-  (clojure->mongo ^IPersistentMap (zipmap fields (repeat 1))))
+  (clojure->mongo ^IPersistentMap (if (map? fields)
+                                    (into {} (for [[k v] fields]
+                                               [k (if v 1 0)]))
+                                    (zipmap fields (repeat 1)))))
 
 
 (defn ^DBObject coerce-index-fields

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -127,6 +127,17 @@
       (is (= (map :x (fetch :points :sort {:x 1})) (sort unsorted)))
       (is (= (map :x (fetch :points :sort {:x -1})) (reverse (sort unsorted)))))))
 
+(deftest fetch-with-only
+  (with-test-mongo
+    (let [data {:_id 10 :foo "clever" :bar "filter"}
+          id (:_id data)]
+      (insert! :with-only data)
+      (are [data-keys select-clause] (= (select-keys data data-keys)
+                                        (fetch-one :with-only :only select-clause))
+           [:_id :foo] [:foo]
+           [:foo :bar] {:_id false}
+           [:_id :bar] {:foo false}))))
+
 (deftest fetch-by-id-of-any-type
   (with-test-mongo
     (insert! :by-id {:_id "Blarney" :val "Stone"})


### PR DESCRIPTION
Truthy values converted to 1, and falsey to 0.
Added a test for :only, both the new and already-existing features.
