### PR TITLE
added fetch-by-ids

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -301,6 +301,9 @@ releases.  Please use 'make-connection' in combination with
 (defn fetch-by-id [col id & options]
   (apply fetch col (concat options [:one? true :where {:_id id}])))
 
+(defn fetch-by-ids [col ids & options]
+  (apply fetch col (concat options [:where {:_id {:$in ids}}])))
+
 (defn with-ref-fetching
   "Returns a decorated fetcher fn which eagerly loads db-refs."
   [fetcher]


### PR DESCRIPTION
I seem to be regularly running into situations in which I want to fetch all documents that match a set of ids.  This adds a convenience function to do just that.  

Example usage:

``` clojure
(fetch-by-ids :users [(object-id "4ee9670b0364335216830a0d") (object-id "4ee9670b0364335216830a0e")])
```
