### PR TITLE
Use coerce-fields for :only arg in fetch-and-modify

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -400,7 +400,7 @@ releases.  Please use 'make-connection' in combination with
                              return-new? false upsert? false from :clojure as :clojure}}]
   (coerce (.findAndModify ^DBCollection (get-coll coll)
                           ^DBObject (coerce where [from :mongo])
-                          ^DBObject (coerce only [from :mongo])
+                          ^DBObject (coerce-fields only)
                           ^DBObject (coerce sort [from :mongo])
                           remove?
                           ^DBObject (coerce update [from :mongo])

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -132,7 +132,10 @@
     (insert! :test_col {:key "123"
                         :value 1})
     (fetch-and-modify :test_col {:key "123"} {:$inc {:value 2}})
-    (is (= 3 (:value (fetch-one :test_col :where {:key "123"}))))))
+    (is (= 3 (:value (fetch-one :test_col :where {:key "123"}))))
+    (let [res (fetch-and-modify :test_col {:key "123"} {:$inc {:value 1}} :only [:value] :return-new? true)]
+      (is (not (contains? res :key)))
+      (is (= 4 (:value res))))))
 
 (deftest collection-existence
   (with-test-mongo


### PR DESCRIPTION
This one is to support vector format for :only parameter
for fetch-and-modify function as it works for regular fetch.
