### PR TITLE
Respect set-write-concern, fix race

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -181,7 +181,8 @@ releases.  Please use 'make-connection' in combination with
    :normal WriteConcern/NORMAL
    :strict WriteConcern/SAFE ;; left for backwards compatibility
    :safe WriteConcern/SAFE
-   :fsync-safe WriteConcern/SAFE})
+   :fsync-safe WriteConcern/FSYNC_SAFE
+   :replica-safe WriteConcern/REPLICAS_SAFE})
 
 (defn set-write-concern
   "Sets the write concern on the connection. Setting is a key in the


### PR DESCRIPTION
 Don't specify the write concern during an insert, thereby respecting the user's previous set-write-concern call.

Now that set-write-concern is respected, it eliminates the need to call .getLastError() after an insert, fixing a race where .getLastError would throw "The connection may have been used since this write, cannot obtain a result" under heavy load.
