### PR TITLE
Fix for `connection?`

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -101,7 +101,7 @@ object may be passed as the last argument."
 
 (defn connection? [x]
   (and (map? x)
-       (:db x)
+       (contains? x :db)
        (:mongo x)))
 
 (defn- ^DB get-db


### PR DESCRIPTION
The `:db` entry in a connection map can be `nil`, since the connection can be used as:

``` clojure
(with-connection c
  (with-db d
    ...))
```

and the check for `c` being a connection is performed before a
database is assigned.
