### PR TITLE
Updating make-connection to accept a Mongo URI String

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -173,7 +173,12 @@ my-robot => { :name "robby",
 ```
 #### advanced initialization using mongo-options
 ```clojure
-((make-connection :mydb :host "127.0.0.1" (mongo-options :auto-connect-retry true)"
+(make-connection :mydb :host "127.0.0.1" (mongo-options :auto-connect-retry true))
+```
+#### initialization using a Mongo URI
+```clojure
+(make-connection "mongodb://user:pass@host:27071/databasename")
+;note that authentication is handled when given a user:pass@ section
 ```
 #### easy json
 ```clojure

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -79,6 +79,20 @@
       ;; check a default option as well
       (is (not (.slaveOk opts))))))
 
+(deftest uri-for-connection
+  (with-test-mongo
+    (let [userpass (if (and test-db-user test-db-pass) (str test-db-user ":" test-db-pass "@") "")
+          uri (str "mongodb://" userpass test-db-host ":" test-db-port "/congomongotest-db-a?autoconnectretry=true&w=1&safe=true")
+          a (make-connection uri)
+          m (:mongo a)
+          opts (.getMongoOptions m)]
+      (testing "make-connection parses options from URI"
+        (is (.safe opts))
+        (is (= 1 (.w opts))))
+      (with-mongo a
+        (testing "make-connection accepts Mongo URI"
+                (is (= "congomongotest-db-a" (.getName (*mongo-config* :db)))))))))
+
 (deftest with-mongo-database
   (with-test-mongo
     (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)]


### PR DESCRIPTION
make-connection tests for mongo:// in the db string and uses MongoURI to parse it in place of passing database/host/port/options.

One piece of note is that the URI supports authentication which is normally handled separately in congomongo. I went ahead and did an authenticate call if user/pass were specified so that user/pass did not have to be stored in memory. If this isn't acceptable, perhaps user/pass should be stored in the connection map and authenticate could optionally check for their definition in the (authenticate connection) case.
