### PR TITLE
removes handling of :force option in add-index! (issue #82)

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -465,13 +465,12 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
 
     Options include:
     :name   -> defaults to the system-generated default
-    :unique -> defaults to false
-    :force  -> defaults to true"
-   {:arglists '([collection fields {:name nil :unique false :force true}])}
-   [c f & {:keys [name unique force]
-           :or {name nil unique false force true}}]
+    :unique -> defaults to false"
+   {:arglists '([collection fields {:name nil :unique false}])}
+   [c f & {:keys [name unique]
+           :or {name nil unique false}}]
    (-> (get-coll c)
-       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:force force :unique unique}
+       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique}
                                                                        (if name {:name name}))
                                                                 [:clojure :mongo]))))
 


### PR DESCRIPTION
I've only removed the references to the :force option in add-index!, but I haven't added a new re-index! function, because I think the existing command function ( https://github.com/aboekhoff/congomongo/blob/master/src/somnium/congomongo.clj#L504-514 ) should be used instead if a reIndex is desired (similary to the Java driver, which doesn't provide a specific reIndex method for this, just the generic command method, http://api.mongodb.org/java/2.7.3/index-all.html ).

The existing tests still run successfully.
