### PR TITLE
adds support for sparse indexes to add-index!

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -465,15 +465,15 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
 
     Options include:
     :name   -> defaults to the system-generated default
-    :unique -> defaults to false"
-   {:arglists '([collection fields {:name nil :unique false}])}
-   [c f & {:keys [name unique]
-           :or {name nil unique false}}]
+    :unique -> defaults to false
+    :sparse -> defaults to false"
+   {:arglists '([collection fields {:name nil :unique false :sparse false}])}
+   [c f & {:keys [name unique sparse]
+           :or {name nil unique false sparse false}}]
    (-> (get-coll c)
-       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique}
+       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse}
                                                                        (if name {:name name}))
                                                                 [:clojure :mongo]))))
-
 (defn drop-index!
   "Drops an index on the collection for the specified fields.
 


### PR DESCRIPTION
I missed this for an app I'm working on, so I've added support for it, and a corresponding test.
http://docs.mongodb.org/manual/core/indexes/#sparse-index

MongoDB's ensureIndex accepts even more parameters (like background or dropDups) that drop-index! doesn't support yet. I thought that drop-index! could just pass the entire options map to the Java driver's ensureIndex method, so that CongoMongo could support all these new parameters and even future ones. This, however, would mean that the available parameters and their default values would not be explicitly visible in CongoMongo's Clojure code, which may not be a desirable thing, or at least is something that should probably be discussed first.

In any case, for the moment, this pull request adds support for sparse indexes without changing how add-index! handles parameters.
