### PR TITLE
Fix #86 by bumping base Clojure version to 1.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,11 +13,11 @@
   :dependencies [[org.clojure/core.incubator "0.1.0"]
                  [org.clojure/data.json "0.1.3"]
                  [org.mongodb/mongo-java-driver "2.8.0"]
-                 [org.clojure/clojure "1.3.0"]]
+                 [org.clojure/clojure "1.4.0"]]
   ;; if a :dev profile is added, remember to update :aliases below to
   ;; use it in each with-profile group!
   :profiles {:1.2  {:dependencies [[org.clojure/clojure "1.2.1"]]}
-             :1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}
+             :1.3  {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.5S {:repositories [["sonatype-snapshots" "https://oss.sonatype.org/content/repositories/snapshots/"]]
                     :dependencies [[org.clojure/clojure "1.5.0-master-SNAPSHOT"]]}}
   :aliases {"test-all" ["with-profile" "default:1.2,default:1.4,default:1.5S,default" "test"]})


### PR DESCRIPTION
Clojure 1.3 is now one of the profiles we test against instead of the base version.
