### PR TITLE
Add MongoDB service to Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: clojure
+services: mongodb
 lein: lein2
 script: lein2 test-all
 jdk:


### PR DESCRIPTION
Travis used to provide MongoDB by default but at some point changed to require an explicit declaration of the service.
