### PR TITLE
Make namespaced keywords round-trippable

### DIFF
--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -70,7 +70,8 @@
                         dbo))
 
   Keyword
-  (clojure->mongo [^Keyword o] (.getName o))
+  (clojure->mongo [^Keyword o] (let [o-ns (namespace o)]
+                                 (str o-ns (when o-ns "/") (name o))))
 
   List
   (clojure->mongo [^List o] (map clojure->mongo o))

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -543,6 +543,15 @@
     (let [return (fetch-one :stuff :where {:name "name"})]
       (is (vector? (:vector return))))))
 
+
+(deftest test-roundtrip-keywords
+  (with-test-mongo
+    (insert! :stuff {:name "name" :some-map {:myns/this 1
+                                             :thatns/this 4}})
+    (let [return (fetch-one :stuff :where {:name "name"})]
+      (is (= 1 (get-in return [:some-map :myns/this]))
+          (= 4 (get-in return [:some-map :thatns/this])) ))))
+
 ;; Note: with Clojure 1.3.0, 1.0 != 1 and the JS stuff returns floating point numbers instead
 ;; of integers so I've changed the tests to use floats in the expected values - except for the
 ;; 1000000 value which _does_ come back as an integer! -- Sean Corfield


### PR DESCRIPTION
At the moment if you insert a namespaced keywork, e.g. :myns/something, congomongo will convert it to the string "something", and it comes back as :something. Reading in the string "myns/something" correctly gives :myns/something.

This is a patch to correctly prepend the namespace in these cases, making keywords properly roundtrippable.
