### PR TITLE
Fix crash in aggregate on MongoDB 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ classes/*
 pom.xml
 /.lein-failures
 /.lein-deps-sum
+/.lein-repl-history
 /.nrepl-port
 /target/
 /pom.xml.asc

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject congomongo
-  "0.5.0"
+(defproject com.timezynk/congomongo
+  "0.6.0"
   :description "Clojure-friendly API for MongoDB"
-  :url "https://github.com/aboekhoff/congomongo"
+  :url "https://github.com/TimeZynk/congomongo"
   :mailing-list {:name "CongoMongo mailing list"
                  :archive "https://groups.google.com/forum/?fromgroups#!forum/congomongo-dev"
                  :post "congomongo-dev@googlegroups.com"}
@@ -10,7 +10,7 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/data.json "0.2.6"]
-                 [org.mongodb/mongo-java-driver "2.14.0"]
+                 [org.mongodb/mongo-java-driver "2.14.2"]
                  [org.clojure/clojure "1.8.0" :scope "provided"]]
   ;; if a :dev profile is added, remember to update :aliases below to
   ;; use it in each with-profile group!

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject congomongo
-  "0.5.1"
+  "0.5.2"
   :description "Clojure-friendly API for MongoDB"
   :url "https://github.com/aboekhoff/congomongo"
   :mailing-list {:name "CongoMongo mailing list"

--- a/readme.markdown
+++ b/readme.markdown
@@ -11,7 +11,11 @@ For Clojure 1.2.1 and earlier, use CongoMongo 0.2.3 or earlier. CongoMongo 0.2.3
 
 News
 --------------
-Version 0.5.1 - Jan 19th, 2017
+Version 0.5.2 - Apr 26th, 2018
+
+* Make aggregate method compatible with MongoDB 3.6
+
+Version 0.5.1 - Jan 19th, 2018
 
 * Add support for setting `_id` when creating GridFS files
 * Update Java driver to 2.14.2


### PR DESCRIPTION
Hi!

We are upgrading our databases to MongoDB 3.6, and noticed a crash when using the aggregate method. Apparently support for cursors in aggregate was added in Java driver 2.12 (See issue #136) and now the old method is deprecated and no longer works on MongoDB 3.6.

I tried to make the change without changing the external API of the function, but I did not find a good way to set the `:ok` member in the resulting map without iterating the cursor and negating the performance benefits. Maybe you have an idea here, or it is an acceptable compromise?

Best Regards
Johan