### PR TITLE
Partial index support

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -597,13 +597,16 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
     :name   -> defaults to the system-generated default
     :unique -> defaults to false
     :sparse -> defaults to false
-    :background -> defaults to false"
-   {:arglists '([collection fields {:name nil :unique false :sparse false}])}
-   [c f & {:keys [name unique sparse background]
+    :background -> defaults to false
+    :partial-filter-expression -> defauls to no filter expression"
+   {:arglists '([collection fields {:name nil :unique false :sparse false :partial-filter-expression nil}])}
+   [c f & {:keys [name unique sparse background partial-filter-expression]
            :or {name nil unique false sparse false background false}}]
    (-> (get-coll c)
        (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse :background background}
-                                                                       (if name {:name name}))
+                                                                       (if name {:name name})
+                                                                       (if partial-filter-expression
+                                                                         {:partialFilterExpression partial-filter-expression}))
                                                                 [:clojure :mongo]))))
 (defn drop-index!
   "Drops an index on the collection for the specified fields.

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -584,6 +584,21 @@
                  (insert! :sparse-index-coll {:a "foo"})))
     (set-write-concern *mongo-config* :unacknowledged)))
 
+(deftest partial-indexing
+  (with-test-mongo
+    (add-index! :partial-index-coll [:a] :unique true :partial-filter-expression {:b {:$gt 5}})
+    (set-write-concern *mongo-config* :acknowledged)
+    (insert! :partial-index-coll {:a "foo" :b 10})
+    (insert! :partial-index-coll {:a "foo" :b 1})
+    (try
+      (insert! :partial-index-coll {:a "foo" :b 2})
+      (is true)
+      (catch MongoException$DuplicateKey e
+        (is false "Unable to insert second document with fields not matching unique partial index")))
+    (is (thrown? MongoException$DuplicateKey
+                 (insert! :partial-index-coll {:a "foo" :b 6})))
+    (set-write-concern *mongo-config* :unacknowledged)))
+
 (deftest index-name
   (with-test-mongo
     (let [coll :test-index-name

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -459,7 +459,7 @@
 (deftest slow-insert-and-fetch
   (with-test-mongo
     (make-points!)
-    (is (= (* 100 100)) (fetch-count :points))
+    (is (= (* 100 100) (fetch-count :points)))
     (is (= (fetch-count :points
                         :where {:x 42}) 100))))
 
@@ -604,8 +604,8 @@
     (let [coll :test-index-name
           index "customIndexName"]
       (add-index! coll [:foo :bar :baz] :name index)
-      (is (= (get (get-index coll index)
-                  "key"))))))
+      (is (= {"foo" 1 "bar" 1 "baz" 1}
+             (get (get-index coll index) "key"))))))
 
 (deftest test-delete-index
   (with-test-mongo


### PR DESCRIPTION
Since 3.2 mongo supports partial indexes (https://docs.mongodb.com/manual/core/index-partial/). This PR enables creation such indexes using congomongo's `add-index!`.