### PR TITLE
Upgrade to the mongo-java-driver 3.x line

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/data.json "0.2.6"]
-                 [org.mongodb/mongo-java-driver "2.14.3"]
+                 [org.mongodb/mongo-java-driver "3.0.4"]
                  [org.clojure/clojure "1.9.0" :scope "provided"]]
   ;; if a :dev profile is added, remember to update :aliases below to
   ;; use it in each with-profile group!

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/data.json "0.2.6"]
-                 [org.mongodb/mongo-java-driver "3.0.4"]
+                 [org.mongodb/mongo-java-driver "3.2.2"]
                  [org.clojure/clojure "1.9.0" :scope "provided"]]
   ;; if a :dev profile is added, remember to update :aliases below to
   ;; use it in each with-profile group!

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject congomongo
-  "0.5.3"
+  "0.6.0"
   :description "Clojure-friendly API for MongoDB"
   :url "https://github.com/congomongo/congomongo"
   :mailing-list {:name "CongoMongo mailing list"

--- a/readme.markdown
+++ b/readme.markdown
@@ -53,8 +53,7 @@ Basics
 ```clojure
 (def conn
   (m/make-connection "mydb"
-                     :host "127.0.0.1"
-                     :port 27017))
+                     :instances {:host "127.0.0.1" :port 27017}))
 => #'user/conn
 
 conn => {:mongo #<MongoClient Mongo: /127.0.0.1:20717>, :db #<DBApiLayer mydb>}
@@ -197,7 +196,9 @@ The aggregate function accepts any number of pipeline operations.
 ```
 #### advanced initialization using mongo-options
 ```clojure
-(m/make-connection :mydb :host "127.0.0.1" (m/mongo-options :auto-connect-retry true))
+(m/make-connection :mydb
+                   :instances [{:host "127.0.0.1"}]
+                   :options (m/mongo-options :auto-connect-retry true))
 ```
 The available options are hyphen-separated lowercase keyword versions of the camelCase options supported by the Java driver. Prior to CongoMongo 0.4.0, the options matched the fields in the *MongoOptions* class. As of CongoMongo 0.4.0, the options match the method names in the *MongoClientOptions* class instead (and an *IllegalArgumentException* will be thrown if you use an illegal option). The full list (with the 2.10.1 Java driver) is:
 ```clojure
@@ -265,6 +266,15 @@ Developer information
 
 Change Log
 ----------
+Version 0.6.0 - Sep 6th, 2018
+
+Updated to support mongo-java-driver 3.0+ which enables use of TLS connections.
+Authentication has changed significantly in the 3.0 driver which necessitated some breaking API changes around connecting and authenticating.
+
+BREAKING CHANGES IN THIS RELEASE!
+* Usernames and passwords for authenticated connections must be supplied to `make-connection` rather than authenticating after the connection has been created. The `make-connection` API has been changed to accomodate this. Optional parameters (instances, Mongo options, username and password) are now passed via keyword args.
+* The `authenticate` function has been removed.
+* The deprecated `mongo!` function has been removed. Use `(set-connection (make-connection ...))`
 
 Version 0.5.3 - Aug 30, 2018
 

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -229,7 +229,6 @@ releases.  Please use 'make-connection' in combination with
 
 (def write-concern-map
   {:acknowledged         WriteConcern/ACKNOWLEDGED
-   :errors-ignored       WriteConcern/ERRORS_IGNORED
    :fsynced              WriteConcern/FSYNCED
    :journaled            WriteConcern/JOURNALED
    :majority             WriteConcern/MAJORITY
@@ -238,7 +237,6 @@ releases.  Please use 'make-connection' in combination with
    ;; these are pre-2.10.x names for write concern:
    :fsync-safe    WriteConcern/FSYNC_SAFE  ;; deprecated - use :fsynced
    :journal-safe  WriteConcern/JOURNAL_SAFE ;; deprecated - use :journaled
-   :none          WriteConcern/NONE ;; deprecated - use :errors-ignored
    :normal        WriteConcern/NORMAL ;; deprecated - use :unacknowledged
    :replicas-safe WriteConcern/REPLICAS_SAFE ;; deprecated - use :replica-acknowledged
    :safe          WriteConcern/SAFE ;; deprecated - use :acknowledged

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -27,7 +27,7 @@
             [somnium.congomongo.config :refer [*mongo-config*]]
             [somnium.congomongo.coerce :refer [coerce coerce-fields coerce-index-fields]])
   (:import  [com.mongodb MongoClient MongoClientOptions MongoClientOptions$Builder MongoClientURI
-             DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes DBCursor
+             DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes
              AggregationOptions AggregationOptions$OutputMode]
             [com.mongodb.gridfs GridFS]
             [com.mongodb.util JSON]
@@ -440,10 +440,11 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
                          ^DBObject n-where
                          ^DBObject n-only)]
                (coerce m [:mongo as]) nil)
-      :else  (when-let [cursor (DBCursor. ^DBCollection n-col
+      :else  (when-let [cursor (.find ^DBCollection n-col
                                       ^DBObject n-where
-                                      ^DBObject n-only
-                                      ^ReadPreference n-preferences)]
+                                      ^DBObject n-only)]
+               (when n-preferences
+                 (.setReadPreference cursor n-preferences))
                (when n-hint
                  (.hint cursor n-hint))
                (when n-options

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -287,8 +287,7 @@ releases.  Please use 'make-connection' in combination with
 (defn db-ref
   "Convenience DBRef constructor."
   [ns id]
-  (DBRef. (get-db *mongo-config*)
-          ^String (named ns)
+  (DBRef. ^String (named ns)
           ^Object id))
 
 (defn db-ref? [x]

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -479,7 +479,9 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
                  :clojure)
           f  (fn [[k v]]
                [k (if (db-ref? v)
-                    (coerce (.fetch ^DBRef v) [:mongo as])
+                    (let [v ^DBRef v
+                          coll (get-coll (.getCollectionName v))]
+                      (coerce (.findOne coll (.getId v)) [:mongo as]))
                     v)])]
       (postwalk (fn [x]
                   (if (map? x)

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -298,7 +298,6 @@ releases.  Please use 'make-connection' in combination with
   [collection]
   (.collectionExists (get-db *mongo-config*)
                      ^String (named collection)))
-
 (defn create-collection!
   "Explicitly create a collection with the given name, which must not already exist.
 
@@ -312,10 +311,10 @@ releases.  Please use 'make-connection' in combination with
    :max    -> int: max number of documents."
   {:arglists
    '([collection :capped :size :max])}
-  ([collection & {:keys [capped size max] :as options}]
-     (.createCollection (get-db *mongo-config*)
-                        ^String (named collection)
-                        (coerce options [:clojure :mongo]))))
+  [collection & {:keys [capped size max] :as options}]
+  (.createCollection (get-db *mongo-config*)
+                     ^String (named collection)
+                     (coerce options [:clojure :mongo])))
 
 (def query-option-map
   {:tailable    Bytes/QUERYOPTION_TAILABLE

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -600,7 +600,7 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
    [c f & {:keys [name unique sparse background partial-filter-expression]
            :or {name nil unique false sparse false background false}}]
    (-> (get-coll c)
-       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse :background background}
+       (.createIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse :background background}
                                                                        (if name {:name name})
                                                                        (if partial-filter-expression
                                                                          {:partialFilterExpression partial-filter-expression}))

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -121,32 +121,34 @@
   (clojure->mongo [o] o))
 
 
+(def ^{:dynamic true
+       :doc "Mapping of [from to] pairs to translation functions for coerce."}
+     *translations* {[:clojure :mongo  ] #'clojure->mongo
+                     [:clojure :json   ] #'write-str
+                     [:mongo   :clojure] #(mongo->clojure ^DBObject % ^boolean *keywordize*)
+                     [:mongo   :json   ] #(.toString ^DBObject %)
+                     [:json    :clojure] #(read-str % :key-fn (if *keywordize*
+                                                                keyword
+                                                                identity))
+                     [:json    :mongo  ] #(JSON/parse %)})
 
-(let [translations {[:clojure :mongo  ] clojure->mongo
-                    [:clojure :json   ] write-str
-                    [:mongo   :clojure] #(mongo->clojure ^DBObject % ^boolean *keywordize*)
-                    [:mongo   :json   ] #(.toString ^DBObject %)
-                    [:json    :clojure] #(read-str % :key-fn (if *keywordize*
-                                                               keyword
-                                                               identity))
-                    [:json    :mongo  ] #(JSON/parse %)}]
-  (defn coerce
-    "takes an object, a vector of keywords:
-     from [ :clojure :mongo :json ]
-     to   [ :clojure :mongo :json ],
-     and an an optional :many keyword parameter which defaults to false"
-    {:arglists '([obj [:from :to]] [obj [:from :to] :many many?])}
-    [obj from-and-to & {:keys [many] :or {many false}}]
-    (let [[from to] from-and-to]
-      (cond (= from to) obj
-            (nil?   to) nil
-            :else       (if-let [f (translations from-and-to)]
-                          (if many
-                            (map f (if (seqable'? obj)
-                                     obj
-                                     (iterator-seq obj)))
-                            (f obj))
-                          (throw (RuntimeException. "unsupported keyword pair")))))))
+(defn coerce
+  "takes an object, a vector of keywords:
+   from [ :clojure :mongo :json ]
+   to   [ :clojure :mongo :json ],
+   and an an optional :many keyword parameter which defaults to false"
+  {:arglists '([obj [:from :to]] [obj [:from :to] :many many?])}
+  [obj from-and-to & {:keys [many] :or {many false}}]
+  (let [[from to] from-and-to]
+    (cond (= from to) obj
+          (nil?   to) nil
+          :else       (if-let [f (*translations* from-and-to)]
+                        (if many
+                          (map f (if (seqable'? obj)
+                                   obj
+                                   (iterator-seq obj)))
+                          (f obj))
+                        (throw (RuntimeException. "unsupported keyword pair"))))))
 
 (defn ^DBObject dbobject [& args]
   "Create a DBObject from a sequence of key/value pairs, in order."

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -177,9 +177,15 @@
   (clojure->mongo ^IPersistentMap (apply array-map
                                          (flatten
                                           (for [f fields]
+                                            ;; Related to https://jira.mongodb.org/browse/JAVA-2757
+                                            ;; Using longs for field specifiers results in dropIndex
+                                            ;; determining an incorrect name for the index.
+                                            ;;
+                                            ;; NOTE: specifiers can be strings for geospatial indices, e.g.
+                                            ;; "2d", "2dsphere"
                                             (if (vector? f)
-                                              f
-                                              [f 1]))))))
+                                              (update-in f [1] (fn [x] (if (number? x) (int x) x)))
+                                              [f (int 1)]))))))
 
 (defn ^DBObject coerce-index-fields
   "Used for creating index specifications.

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -126,7 +126,7 @@
      *translations* {[:clojure :mongo  ] #'clojure->mongo
                      [:clojure :json   ] #'write-str
                      [:mongo   :clojure] #(mongo->clojure ^DBObject % ^boolean *keywordize*)
-                     [:mongo   :json   ] #(.toString ^DBObject %)
+                     [:mongo   :json   ] #(JSON/serialize %)
                      [:json    :clojure] #(read-str % :key-fn (if *keywordize*
                                                                 keyword
                                                                 identity))

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -6,6 +6,7 @@
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
   (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder DuplicateKeyException
+                        Tag TagSet
             ReadPreference
             WriteConcern]
            [org.bson.types ObjectId]))
@@ -886,20 +887,19 @@ function ()
 
 
 (deftest test-read-preference
-  (let [^DBObject f-tag (BasicDBObject. "location" "nearby")
-        r-tags (into-array DBObject [(BasicDBObject. "rack" "bottom")])
-        empty-tags (into-array DBObject [])]
+  (let [f-tag (TagSet. (Tag. "location" "nearby"))
+        r-tags (TagSet. (Tag. "rack" "bottom"))]
     (are [expected type tags] (= expected (apply read-preference (cons type tags)))
       (ReadPreference/nearest) :nearest nil
-      (ReadPreference/nearest f-tag empty-tags) :nearest [{:location "nearby"}]
-      (ReadPreference/nearest f-tag r-tags) :nearest [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/nearest f-tag) :nearest [{:location "nearby"}]
+      (ReadPreference/nearest [f-tag r-tags]) :nearest [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/primary) :primary nil
       (ReadPreference/primaryPreferred) :primary-preferred nil
-      (ReadPreference/primaryPreferred f-tag empty-tags) :primary-preferred [{:location "nearby"}]
-      (ReadPreference/primaryPreferred f-tag r-tags) :primary-preferred [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/primaryPreferred f-tag) :primary-preferred [{:location "nearby"}]
+      (ReadPreference/primaryPreferred [f-tag r-tags]) :primary-preferred [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/secondary) :secondary nil
-      (ReadPreference/secondary f-tag empty-tags) :secondary [{:location "nearby"}]
-      (ReadPreference/secondary f-tag r-tags) :secondary [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/secondary f-tag) :secondary [{:location "nearby"}]
+      (ReadPreference/secondary [f-tag r-tags]) :secondary [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/secondaryPreferred) :secondary-preferred nil
       )))
 

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -51,11 +51,13 @@
   (doseq [^String coll (collections)]
     (when-not (.startsWith coll "system")
       (drop-coll! coll))))
+
 (defn setup! []
   (mongo! :db test-db :host test-db-host :port test-db-port)
   (when (and test-db-user test-db-pass)
     (authenticate test-db-user test-db-pass)
     (drop-test-collections!)))
+
 (defn teardown! []
   (if (and test-db-user test-db-pass)
     (try ; some tests don't authenticate so ignore failures here:
@@ -66,8 +68,10 @@
 (defmacro with-test-mongo [& body]
   `(do
      (setup!)
-     ~@body
-     (teardown!)))
+     (try
+      ~@body
+      (finally
+        (teardown!)))))
 
 (deftest options-on-connections
   (with-test-mongo

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -924,6 +924,12 @@ function ()
     (set-collection-write-concern! :with-write-concern :unacknowledged )
     (is (= WriteConcern/UNACKNOWLEDGED (get-collection-write-concern :with-write-concern )))))
 
+(deftest deferred-collection-creation-does-not-throw
+  ;; See https://jira.mongodb.org/browse/JAVA-1970
+  (with-test-mongo
+    (let [db (-> *mongo-config* :mongo (.getDB test-db))]
+      (is (instance? DBCollection (.createCollection db "no-options-so-deferred-creation" nil))))))
+
 (deftest index-names-include-asc-desc-information
   ;; See https://jira.mongodb.org/browse/JAVA-1971
   (with-test-mongo

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -358,10 +358,10 @@
     (is (thrown? IllegalArgumentException
                  (fetch-one :stuff :sort {:a 1})))))
 
-(deftest fetch-one-with-read-preferences-fails
+(deftest fetch-one-with-read-preferences-does-not-explode
   (with-test-mongo
-    (is (thrown? IllegalArgumentException
-                 (fetch-one :test_col :read-preferences :secondary)))))
+    (insert! :test_col {:foo "bar"})
+    (is (fetch-one :test_col :read-preferences :secondary))))
 
 (deftest fetch-one-with-hint-fails
   (with-test-mongo

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -79,15 +79,15 @@
   (with-test-mongo
     ;; set some non-default option values
     (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port
-                             (mongo-options :auto-connect-retry true
+                             (mongo-options :connect-timeout 500
                                             :write-concern (:acknowledged write-concern-map)))
          ^MongoClient m (:mongo a)
-          opts (.getMongoOptions m)]
+          opts (.getMongoClientOptions m)]
       ;; check non-default options attached to Mongo object
-      (is (.isAutoConnectRetry opts))
+      (is (= 500 (.getConnectTimeout opts)))
       (is (= WriteConcern/ACKNOWLEDGED (.getWriteConcern opts)))
       ;; check a default option as well
-      (is (not (.slaveOk opts))))))
+      (is (= (ReadPreference/primary) (.getReadPreference opts))))))
 
 (deftest uri-for-connection
   (with-test-mongo

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -6,11 +6,13 @@
         clojure.pprint)
   (:require [clojure.data.json :refer (read-str write-str)]
             [clojure.set :as set])
-  (:import [com.mongodb DB DBCollection DBObject BasicDBObject BasicDBObjectBuilder
+  (:import [java.nio.charset Charset]
+           [java.security MessageDigest]
+           [com.mongodb DB DBCollection DBObject BasicDBObject BasicDBObjectBuilder
                         MongoClient MongoException DuplicateKeyException MongoCommandException
                         Tag TagSet
-            ReadPreference
-            WriteConcern]
+                        ReadPreference
+                        WriteConcern]
            [org.bson.types ObjectId]))
 
 (deftest coercions
@@ -55,10 +57,10 @@
       (drop-coll! coll))))
 
 (defn setup! []
-  (mongo! :db test-db :host test-db-host :port test-db-port)
-  (when (and test-db-user test-db-pass)
-    (authenticate test-db-user test-db-pass)
-    (drop-test-collections!)))
+  (set-connection! (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :username test-db-user
+                                            :password test-db-pass))
+  (drop-test-collections!))
 
 (defn teardown! []
   (if (and test-db-user test-db-pass)
@@ -75,12 +77,128 @@
       (finally
         (teardown!)))))
 
+(defn- version
+  [db]
+  (-> *mongo-config*
+      :mongo
+      (.getDB db)
+      (.command "buildInfo")
+      (.getString "version")))
+
+(defn- mongo-hash
+  "Uses the same hashing algorithm as
+  https://github.com/mongodb/mongo/blob/09917767b116f4ff1c0eadda1e8bc5db30828500/src/mongo/shell/db.js#L149"
+  [username passphrase]
+  (let [hex-strings (vec (for [a ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f"]
+                               b ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f"]]
+                           (str a b)))
+        ->bytes (fn [s] (.getBytes s (Charset/forName "UTF-8")))
+        digest-bytes (.digest
+                        (doto (MessageDigest/getInstance "MD5")
+                              (.reset)
+                              (.update (->bytes username))
+                              (.update (->bytes ":mongo:"))
+                              (.update (->bytes passphrase))))]
+    (apply str (map #(get hex-strings (bit-and 0xff %)) digest-bytes))))
+
+(defmacro with-test-user
+  [username password & body]
+  `(let [username# ~username
+         password# ~password]
+    (try
+      (cond
+        (= "2.2" (subs (version test-db) 0 3))
+        ;; 2.2 uses a different user creation algorithm to 2.4
+        (is false "Not implemented for 2.2 databases")
+
+        (= "2.4" (subs (version test-db) 0 3))
+        ;; 2.4 mongodb doesn't have a command to create users. Manually hash
+        ;; the password and insert directly
+        (insert! :system.users {:user username#
+                                :pwd (mongo-hash username# password#)
+                                :roles ["readWrite"]})
+
+        :else
+        (let [create-user-cmd# (.. (BasicDBObjectBuilder/start)
+                                   (add "createUser" username#)
+                                   (add "pwd" password#)
+                                   (add "roles" [(BasicDBObject. {"role" "readWrite", "db" test-db})])
+                                   (get))]
+          (.command ^DB (get-db *mongo-config*)
+                    ^DBObject create-user-cmd#)))
+      ~@body
+      (finally
+        (.command ^DB (get-db *mongo-config*)
+                  ^DBObject (coerce {:dropUser username#} [:clojure :mongo]))))))
+
+(deftest authentication-works
+  (with-test-mongo
+    (with-test-user "test_user" "test_password"
+      (testing "valid credentials work"
+        (let [conn (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :username "test_user"
+                                            :password "test_password")]
+          ;; Just validate that we can interact with the DB, the 3.0 Mongo driver
+          ;; has removed any way to check if a connection is authenticated.
+          (with-mongo conn
+            (insert! :thingies {:foo 1})
+            (is (= 1 (:foo (fetch-one :thingies :where {:foo 1}))))
+
+          (close-connection conn))))
+
+      (testing "invalid credentials throw"
+        (let [conn (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :options (mongo-options :server-selection-timeout 1000)
+                                            :username "not_a_valid_user"
+                                            :password "not_a_valid_password")]
+          (is (thrown? MongoException
+                       (with-mongo conn
+                         (insert! :thingies {:foo 1}))))
+
+          (close-connection conn)))
+
+      (testing "credentials with Mongo URIs"
+        (let [conn (make-connection (format "mongodb://test_user:test_password@127.0.0.1:27017/%s" test-db))]
+          ;; Just validate that we can interact with the DB, the 3.0 Mongo driver
+          ;; has removed any way to check if a connection is authenticated.
+          (with-mongo conn
+            (insert! :thingies {:foo 1})
+            (is (= 1 (:foo (fetch-one :thingies :where {:foo 1}))))
+
+          (close-connection conn))))
+
+      (testing "bad credentials in a MongoURI"
+        ;; This adds a 30 second wait to the test suite when using the 3.0 driver.
+        ;; Since all connections are authenticated the server selection times
+        ;; out due to invalid credentials.
+        ;; Unlike MongoClient, http://api.mongodb.org/java/current/com/mongodb/MongoClientURI.html
+        ;; does not allow the server selection timeout to be set
+        (let [conn (make-connection (format "mongodb://invalid_user:test_password@127.0.0.1:27017/%s" test-db))]
+          (is (thrown? MongoException
+                       (with-mongo conn
+                         (insert! :thingies {:foo 1}))))
+
+          (close-connection conn))))))
+
+(deftest make-connection-variations
+  (testing "No optional arguments"
+    (is (make-connection test-db)))
+
+  (testing "Username/password combinations"
+    (is (thrown-with-msg? IllegalArgumentException #"Username and password must both be supplied"
+          (make-connection test-db :username "foo" :password nil)))
+
+    (is (thrown-with-msg? IllegalArgumentException #"Username and password must both be supplied"
+          (make-connection test-db :username nil :password "bar")))
+
+    (is (make-connection test-db :username nil :password nil))))
+
 (deftest options-on-connections
   (with-test-mongo
     ;; set some non-default option values
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port
-                             (mongo-options :connect-timeout 500
-                                            :write-concern (:acknowledged write-concern-map)))
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}]
+                                                   :options (mongo-options :connect-timeout 500
+                                                                           :write-concern (:acknowledged write-concern-map)))
          ^MongoClient m (:mongo a)
           opts (.getMongoClientOptions m)]
       ;; check non-default options attached to Mongo object
@@ -105,7 +223,7 @@
 
 (deftest with-mongo-database
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (with-db "congomongotest-db-b"
           (testing "with-mongo uses new database"
@@ -115,20 +233,20 @@
 
 (deftest with-mongo-interactions
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)
-          b (make-connection :congomongotest-db-b :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])
+          b (make-connection :congomongotest-db-b :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (testing "with-mongo sets the mongo-config"
           (is (= "congomongotest-db-a" (.getName ^DB (*mongo-config* :db)))))
-        (testing "mongo! inside with-mongo stomps on current config"
-          (mongo! :db "congomongotest-db-b" :host test-db-host :port test-db-port)
-          (is (= "congomongotest-db-b" (.getName ^DB (*mongo-config* :db))))))
-      (testing "and previous mongo! inside with-mongo is visible afterwards"
-        (is (= "congomongotest-db-b" (.getName ^DB (*mongo-config* :db))))))))
+        (testing "set-connection! inside with-mongo stomps on current config"
+          (set-connection! (make-connection "congomongotest-db-c" :instances [{:host test-db-host :port test-db-port}]))
+          (is (= "congomongotest-db-c" (.getName ^DB (*mongo-config* :db))))))
+      (testing "and previous set-connection! inside with-mongo is visible afterwards"
+        (is (= "congomongotest-db-c" (.getName ^DB (*mongo-config* :db))))))))
 
 (deftest closing-with-mongo
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (testing "close-connection inside with-mongo sets mongo-config to nil"
           (close-connection a)
@@ -300,13 +418,8 @@
 
 (deftest fetch-with-hint-changes-index
   (with-test-mongo
-    (let [version (-> *mongo-config*
-                      :mongo
-                      (.getDB test-db)
-                      (.command "buildInfo")
-                      (.getString "version"))
-          mongo2? (-> version (.startsWith "2"))
-          mongo3? (-> version (.startsWith "3"))]
+    (let [mongo2? (-> test-db version (.startsWith "2"))
+          mongo3? (-> test-db version (.startsWith "3"))]
 
       ;; only 1 versions
       (is (or mongo2? mongo3?))

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -216,7 +216,7 @@
           opts (.getMongoOptions m)]
       (testing "make-connection parses options from URI"
         (is (= 123 (.getConnectionsPerHost opts)))
-        (is (= WriteConcern/ACKNOWLEDGED (.getWriteConcern opts))))
+        (is (= WriteConcern/W1 (.getWriteConcern opts))))
       (with-mongo a
         (testing "make-connection accepts Mongo URI"
                 (is (= "congomongotest-db-a" (.getName ^DB (*mongo-config* :db)))))))))

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -5,7 +5,7 @@
         somnium.congomongo.coerce
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
-  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder MongoException$DuplicateKey
+  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder DuplicateKeyException
             ReadPreference
             WriteConcern]
            [org.bson.types ObjectId]))
@@ -578,9 +578,9 @@
     (try
       (insert! :sparse-index-coll {})
       (is true)
-      (catch MongoException$DuplicateKey e
+      (catch DuplicateKeyException e
         (is false "Unable to insert second document without the sparse index key")))
-    (is (thrown? MongoException$DuplicateKey
+    (is (thrown? DuplicateKeyException
                  (insert! :sparse-index-coll {:a "foo"})))
     (set-write-concern *mongo-config* :unacknowledged)))
 
@@ -593,9 +593,9 @@
     (try
       (insert! :partial-index-coll {:a "foo" :b 2})
       (is true)
-      (catch MongoException$DuplicateKey e
+      (catch DuplicateKeyException e
         (is false "Unable to insert second document with fields not matching unique partial index")))
-    (is (thrown? MongoException$DuplicateKey
+    (is (thrown? DuplicateKeyException
                  (insert! :partial-index-coll {:a "foo" :b 6})))
     (set-write-concern *mongo-config* :unacknowledged)))
 


### PR DESCRIPTION
We've been using these patches on a fork of congomongo for a while, now that
congomongo is maintained again it would be good to get them back upstream.

This PR is a result of rebasing our patches onto the current `master` so it's
not quite what we've been running in production since there have been some
commits to `master` since we forked.

There is a [breaking API change](https://github.com/congomongo/congomongo/commit/c91a3c84cc4e4dc664152a2665f13bdf47e973ac) due to changes in how authentication is handled,
I've bumped the version number to 0.6.0 as a result, happy to change that to
whatever you feel is suitable.

I've run the test suite against MongoDB 3.2 and 2.6.8, all tests pass for me
locally.

This is a large PR, I hope the sequence of commits is self-explanatory, if not
let me know and I'll do my best to work out a series of commits/PRs that make sense.