### PR TITLE
added support for default query options

### DIFF
--- a/src/somnium/congomongo/config.clj
+++ b/src/somnium/congomongo/config.clj
@@ -21,3 +21,4 @@
 (ns somnium.congomongo.config)
 
 (def ^{:dynamic true} *mongo-config* {})
+(def ^{:dynamic true} *default-query-options* {})


### PR DESCRIPTION
Sometimes it's very helpful to be able to provide default options for all queries (for example, specify default `max-time-ms` timeout) instead of specifying it for each call. This PR adds this option by providing `with-default-query-options` macro. Options specified in a particular call will have a priority and overwrite `default-query-options`.
