### PR TITLE
Remove uses of deprecated JSON API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  mongodb:
+    image: mongo:3.6
+    ports:
+      - '127.0.0.1:27017:27017'

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/data.json "0.2.7"]
-                 [org.mongodb/mongo-java-driver "3.10.2"]
+                 [org.mongodb/mongo-java-driver "3.12.10"]
                  [org.clojure/clojure "1.10.1" :scope "provided"]]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
   ;; if a :dev profile is added, remember to update :aliases below to

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
             :url "http://www.opensource.org/licenses/mit-license.php"
             :distribution :repo}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/data.json "0.2.7"]
+  :dependencies [[org.clojure/data.json "2.4.0"]
                  [org.mongodb/mongo-java-driver "3.12.10"]
                  [org.clojure/clojure "1.10.1" :scope "provided"]]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -20,11 +20,17 @@
 
 (ns somnium.congomongo.coerce
   (:require [clojure.data.json :refer [write-str read-str]])
-  (:import [clojure.lang IPersistentMap IPersistentVector Keyword]
+  (:import [clojure.lang IPersistentMap Keyword]
            [java.util Map List Set]
            [com.mongodb DBObject BasicDBObject BasicDBList]
-           [com.mongodb.gridfs GridFSFile]
-           [com.mongodb.util JSON]))
+           [org.bson.json JsonWriterSettings JsonMode]))
+
+(def ^:private json-settings
+  ; Create a settings object to allow us to serialize an object with "RELAXED" JSON.
+  ; https://github.com/mongodb/specifications/blob/df6be82f865e9b72444488fd62ae1eb5fca18569/source/extended-json.rst
+  (-> (JsonWriterSettings/builder)
+      (.outputMode JsonMode/RELAXED)
+      (.build)))
 
 (def ^{:dynamic true
        :doc "Set this to false to prevent coercion from setting string keys to keywords"
@@ -46,6 +52,13 @@
         (.isArray (.getClass ^Object x))
         (string? x)
         (instance? java.util.Map x))))
+
+(defn json->mongo [^String s]
+  (BasicDBObject/parse s))
+
+(defn ^String mongo->json [^BasicDBObject dbo]
+  (.toJson dbo json-settings))
+
 
 ;;; Converting data from mongo into Clojure data objects
 
@@ -126,11 +139,11 @@
      *translations* {[:clojure :mongo  ] #'clojure->mongo
                      [:clojure :json   ] #'write-str
                      [:mongo   :clojure] #(mongo->clojure ^DBObject % ^boolean *keywordize*)
-                     [:mongo   :json   ] #(JSON/serialize %)
+                     [:mongo   :json   ] #'mongo->json
                      [:json    :clojure] #(read-str % :key-fn (if *keywordize*
                                                                 keyword
                                                                 identity))
-                     [:json    :mongo  ] #(JSON/parse %)})
+                     [:json    :mongo  ] #'json->mongo})
 
 (defn coerce
   "takes an object, a vector of keywords:
@@ -150,8 +163,9 @@
                           (f obj))
                         (throw (RuntimeException. "unsupported keyword pair"))))))
 
-(defn ^DBObject dbobject [& args]
-  "Create a DBObject from a sequence of key/value pairs, in order."
+(defn ^DBObject dbobject
+   "Create a DBObject from a sequence of key/value pairs, in order."
+  [& args]
   (let [dbo (BasicDBObject.)]
     (doseq [[k v] (partition 2 args)]
       (.put dbo

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -57,14 +57,17 @@
 (defn json->mongo [^String s]
   (BasicDBObject/parse s))
 
+;; extend data.json to handle mongo types.
+;; we ignore the options argument; we do not need to set any of them.
+
 (defn- write-basic-db-object
-  [^BasicDBObject dbo ^Appendable out]
+  [^BasicDBObject dbo ^Appendable out _options]
   (.append out (.toJson dbo json-settings)))
 
 (extend BasicDBObject clojure.data.json/JSONWriter {:-write write-basic-db-object})
 
 (defn write-object-id
-  [^ObjectId id ^Appendable out]
+  [^ObjectId id ^Appendable out _options]
   (.append out "\"")
   (.append out (str id))
   (.append out "\""))


### PR DESCRIPTION
The version 3.12 of the Java driver deprecates `com.mongodb.util.JSON`
in favour of the JSON functions on the DBObject class. The deprecated
API will be removed in driver version 4.x.

In order to prepare for the upgrade to 4.x we can upgrade from driver
`3.10` to `3.12` and remove calls to the decprecated API.