### PR TITLE
Improve the build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 jobs:
-  build:
+  build-3.6:
     docker:
       # specify the version you desire here
       - image: circleci/clojure:lein-2.9.5
@@ -38,7 +38,41 @@ jobs:
       # run tests!
       - run: lein test
 
+  build-4.2:
+    docker:
+      # specify the version you desire here
+      - image: circleci/clojure:lein-2.9.5
+      - image: mongo:4.2
+
+    working_directory: ~/repo
+
+    environment:
+      LEIN_ROOT: "true"
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: lein deps
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+      # run tests!
+      - run: lein test :all
+
 workflows:
   build:
     jobs:
-      - build
+      - build-3.6
+      - build-4.2

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ What?
 ------
 A toolkit for using MongoDB with Clojure. This library is a pretty lightweight wrapper around the MongoDB Java driver, and can be paired with your favorite framworks or functions for validation such as [clojure.spec.alpha](https://clojure.org/guides/spec).
 
+Supported MongoDB versions
+----------------------------------------
+
+The client was tested with the following MongoDB versions:
+- MongoDB 3.6
+- MongoDB 4.2
+
+Thus, while the library may work just fine with higher MongoDB versions, the full feature support is not guaranteed.
+
 Releases and Dependency Information
 ----------------------------------------
 

--- a/project.clj
+++ b/project.clj
@@ -17,5 +17,7 @@
   ;; use it in each with-profile group!
   :profiles {:1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
+  :test-selectors {:default (complement :mongo-4.2+)
+                   :mongo-4.2+ :mongo-4.2+}
   :aliases {"test-all" ["with-profile" "default,1.9:default,1.10" "test"]}
   :plugins [[lein-cljfmt "0.8.0"]])


### PR DESCRIPTION
Run tests in CircleCI for both supported MongoDB versions (3.6 and 4.2).

All tests should pass just fine with the current build configuration, but the updated one clearly indicates those tests that only match MongoDB 4.2+.