### PR TITLE
ERROR IN CONFIG FILE: [#/jobs] 2 schema violations found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 jobs:
-  build-3.6:
+  build-3-6:
     docker:
       # specify the version you desire here
       - image: circleci/clojure:lein-2.9.5
@@ -38,7 +38,7 @@ jobs:
       # run tests!
       - run: lein test
 
-  build-4.2:
+  build-4-2:
     docker:
       # specify the version you desire here
       - image: circleci/clojure:lein-2.9.5
@@ -74,5 +74,5 @@ jobs:
 workflows:
   build:
     jobs:
-      - build-3.6
-      - build-4.2
+      - build-3-6
+      - build-4-2


### PR DESCRIPTION
Any string key is allowed as job name.
1. [#/jobs/build-3.6] string [build-3.6] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$
2. [#/jobs/build-4.2] string [build-4.2] does not match pattern ^[A-Za-z][A-Za-z\s\d_-]*$

@jheander Hi Johan! Let's merge to fix the build pipeline. An extra lib release is not needed.

P.S. Sorry for being a CircleCI noob.